### PR TITLE
Fixing deprecated tests, non-quiet Ladle causing test failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: ruby
+cache: bundler
+sudo: false
+bundler_args: --without debug
+env:
+  global:
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+rvm:
+ - 2.2
+before_script:
+  - jdk_switcher use oraclejdk8

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Hydra::LDAP
 
+[![Build Status](https://travis-ci.org/projecthydra-labs/hydra-works.svg?branch=master)](https://travis-ci.org/projecthydra-labs/hydra-works)
+[![Contribution Guidelines](http://img.shields.io/badge/CONTRIBUTING-Guidelines-blue.svg)](./CONTRIBUTING.md)
+
 A gem for managing ldap groups used with hydra
 
 ## Installation

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 
-require 'rspec/autorun'
 require 'hydra-ldap'
 require 'ladle'
 


### PR DESCRIPTION
* Using expect() syntax
* Adding "quiet" parameter to Ladle config to fix test failures